### PR TITLE
Fix CI/CD Pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -54,6 +54,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     steps:
+        - name: Checkout code
+          uses: actions/checkout@v4
+
         - name: Set up JDK
           uses: actions/setup-java@v4
           with:


### PR DESCRIPTION
# Fix CI/CD Pipeline

This is linked to #27 

## Description

This PR simplifies the CI/CD pipeline by commenting out PostgreSQL services, and uses the H2 in-memory DB to test the backend.

### PostgreSQL Services
- Commented out for now to simplify the pipeline and ensure other steps run correctly.

### Debugging
- After testing on cicd-setup branch, the pipeline starts without errors and works. However, the workflow failed at the frontend step due to an error running tests with Jest in App.test.js.


## Testing

### Setup
- Commit workflow YAML to a separate branch
- Open a Pull Request to main

### Verify
- Check Actions tab to verify if workflow is running
- Ensure frontend tests pass successfully
- Ensure backend tests pass and Jacoco report is generated
- Verify Docker images build without errors