### PR TITLE
Frontend Fixes

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -12,12 +12,20 @@ import { useAnalytics } from './hooks/useAnalytics';
 import SurplusForm from './components/SurplusForm';
 import './App.css';
 
+import { useLocation } from "react-router-dom";
+
 function AppContent() {
   useAnalytics(); // This will track page views automatically
+  const location = useLocation();
+
+  // Hide navbar on login and registration pages
+  const hideNavbar =
+    location.pathname === "/login" ||
+    location.pathname.startsWith("/register");
 
   return (
     <div className="App">
-      <NavigationBar />
+      {!hideNavbar && <NavigationBar />}
       <Routes>
         <Route path="/" element={<LandingPage />} />
         <Route path="/register" element={<RegisterType />} />

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -10,6 +10,7 @@ import NavigationBar from './components/NavigationBar';
 import { AuthProvider } from './contexts/AuthContext';
 import { useAnalytics } from './hooks/useAnalytics';
 import SurplusForm from './components/SurplusForm';
+import PrivacyPolicy from './components/PrivacyPolicy'; 
 import './App.css';
 
 import { useLocation } from "react-router-dom";
@@ -34,6 +35,7 @@ function AppContent() {
         <Route path="/login" element={<LoginPage />} />
         <Route path="/dashboard" element={<TempDashboard />} />
         <Route path="/surplus/create" element={<SurplusForm />} />
+         <Route path="/privacy-policy" element={<PrivacyPolicy />} /> 
       </Routes>
     </div>
   );

--- a/frontend/src/components/Footer.js
+++ b/frontend/src/components/Footer.js
@@ -37,11 +37,11 @@ const Footer = () => {
               <div className="contact-info">
                 <div className="contact-item">
                   <FaEnvelope className="contact-icon" />
-                  <span className="contact-email">foodflow.group@gmail.com</span>
+                  <a href="mailto:foodflow.group@gmail.com" className="contact-email">foodflow.group@gmail.com</a>
                 </div>
                 <div className="contact-item">
                   <FaPhone className="contact-icon" />
-                  <span className="contact-phone">1-800-122-4567</span>
+                  <a href="tel:18001224567" className="contact-phone">1-800-122-4567</a>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/LoginPage.js
+++ b/frontend/src/components/LoginPage.js
@@ -53,6 +53,13 @@ const LoginPage = () => {
         <div className="login-container">
           <div className="login-inner">
             <div className="login-card" role="region" aria-labelledby="login-title">
+              <button
+                className="back-home-button"
+                onClick={() => navigate("/")}
+                aria-label="Go back to homepage"
+              >
+                ← Back Home
+              </button>
               <h1 id="login-title" className="login-title">Log in to your account</h1>
 
               <form onSubmit={handleLogin} noValidate>

--- a/frontend/src/components/LoginPage.js
+++ b/frontend/src/components/LoginPage.js
@@ -95,7 +95,7 @@ const LoginPage = () => {
                   {loading ? 'Logging in…' : 'LOG IN'}
                 </button>
 
-                <p className="form-footer">Don't have an account? <Link to="/signup">Sign up</Link></p>
+                <p className="form-footer">Don't have an account? <button type="button" className="link-button" onClick={() => navigate("/register")}>Sign up</button></p>
               </form>
             </div>
           </div>

--- a/frontend/src/components/PrivacyPolicy.js
+++ b/frontend/src/components/PrivacyPolicy.js
@@ -1,0 +1,209 @@
+import React, { useEffect, useState } from "react";
+
+const PrivacyPolicy = () => {
+  const [fadeIn, setFadeIn] = useState(false);
+
+  useEffect(() => {
+    setTimeout(() => setFadeIn(true), 50);
+  }, []);
+
+  const styles = {
+    wrapper: {
+      backgroundColor: "#F9FAF9", 
+      minHeight: "100vh",
+      display: "flex",
+      justifyContent: "center",
+      alignItems: "flex-start",
+      padding: "4rem 1rem",
+      fontFamily: "Poppins, sans-serif",
+    },
+    container: {
+      backgroundColor: "#FFFFFF",
+      borderRadius: "20px",
+      boxShadow: "0 4px 15px rgba(0, 0, 0, 0.08)",
+      padding: "4.5rem 3rem",
+      maxWidth: "1000px",
+      width: "100%",
+      color: "#1a1a1a",
+      lineHeight: 1.7,
+      opacity: fadeIn ? 1 : 0,
+      transform: fadeIn ? "translateY(0)" : "translateY(15px)",
+      transition: "opacity 0.6s ease, transform 0.6s ease",
+      fontSize: "1.1rem",
+    },
+    title: {
+      color: "#1B4965",
+      fontSize: "2.25rem",
+      fontWeight: "700",
+      marginBottom: "0.5rem",
+      textAlign: "center",
+    },
+    updated: {
+      color: "#777",
+      fontSize: "1rem",
+      marginBottom: "2.5rem",
+      textAlign: "center",
+    },
+    section: {
+      marginBottom: "2rem",
+    },
+    heading: {
+      color: "#1B4965",
+      fontSize: "1.4rem",
+      fontWeight: "600",
+      marginBottom: "0.6rem",
+    },
+    list: {
+      paddingLeft: "1rem",
+      margin: 0,
+    },
+    link: {
+      color: "#609B7E",
+      textDecoration: "none",
+      fontWeight: 500,
+    },
+    button: {
+      display: "inline-block",
+      marginTop: "2rem",
+      backgroundColor: "#609B7E",
+      color: "#fff",
+      padding: "0.75rem 1.5rem",
+      borderRadius: "10px",
+      border: "none",
+      fontSize: "1rem",
+      fontWeight: "500",
+      cursor: "pointer",
+      transition: "background-color 0.3s ease",
+    },
+    buttonHover: {
+      backgroundColor: "#4f866d",
+    },
+    footer: {
+      textAlign: "center",
+      marginTop: "1.5rem",
+    },
+  };
+
+  const [hover, setHover] = useState(false);
+
+  return (
+    <div style={styles.wrapper}>
+      <div style={styles.container}>
+        <h1 style={styles.title}>Privacy Policy</h1>
+        <p style={styles.updated}>Last updated: October 2025</p>
+
+        <section style={styles.section}>
+          <h2 style={styles.heading}>1. Introduction</h2>
+          <p>
+            FoodFlow (“we”, “our”, “us”) respects your privacy and is committed to protecting your
+            personal data. This Privacy Policy explains how we collect, use, and protect your
+            information when you use our platform to donate or receive surplus food.
+          </p>
+        </section>
+
+        <section style={styles.section}>
+          <h2 style={styles.heading}>2. Information We Collect</h2>
+          <ul style={styles.list}>
+            <li>
+              <strong>Account Information:</strong> Name, email, and phone number provided during registration.
+            </li>
+            <li>
+              <strong>Donation Details:</strong> Food type, quantity, expiry date, pickup location, and notes you submit.
+            </li>
+            <li>
+              <strong>Usage Data:</strong> Pages visited and interactions to help us improve our service.
+            </li>
+            <li>
+              <strong>Device Data:</strong> Browser, operating system, and IP address for security and debugging.
+            </li>
+          </ul>
+        </section>
+
+        <section style={styles.section}>
+          <h2 style={styles.heading}>3. How We Use Your Information</h2>
+          <ul style={styles.list}>
+            <li>To connect donors with nearby receivers.</li>
+            <li>To manage your account and improve your experience.</li>
+            <li>To maintain safety and prevent fraudulent activity.</li>
+            <li>To comply with legal and regulatory obligations.</li>
+          </ul>
+        </section>
+
+        <section style={styles.section}>
+          <h2 style={styles.heading}>4. Data Sharing</h2>
+          <p>
+            We never sell your personal data. We may share limited information with trusted third
+            parties such as:
+          </p>
+          <ul style={styles.list}>
+            <li>Service providers (hosting, analytics) helping us operate the platform.</li>
+            <li>Authorities when required by law or to prevent harm or misuse.</li>
+          </ul>
+        </section>
+
+        <section style={styles.section}>
+          <h2 style={styles.heading}>5. Data Retention</h2>
+          <p>
+            We retain your information only as long as necessary to provide our services. You may
+            request deletion at any time by emailing{" "}
+            <a href="mailto:support@foodflow.ca" style={styles.link}>
+              support@foodflow.ca
+            </a>.
+          </p>
+        </section>
+
+        <section style={styles.section}>
+          <h2 style={styles.heading}>6. Your Rights</h2>
+          <p>
+            You have the right to access, correct, or delete your data and to withdraw consent to
+            processing at any time. Requests can be made by contacting us directly.
+          </p>
+        </section>
+
+        <section style={styles.section}>
+          <h2 style={styles.heading}>7. Security</h2>
+          <p>
+            We apply technical and organizational measures such as encryption and restricted access
+            to protect your data. However, no online service is entirely risk-free.
+          </p>
+        </section>
+
+        <section style={styles.section}>
+          <h2 style={styles.heading}>8. Changes to This Policy</h2>
+          <p>
+            We may update this Privacy Policy periodically. Any changes will be reflected on this
+            page with an updated revision date.
+          </p>
+        </section>
+
+        <section style={styles.section}>
+          <h2 style={styles.heading}>9. Contact Us</h2>
+          <p>
+            If you have any questions or concerns about this Privacy Policy, reach out to:
+          </p>
+          <p>
+            <strong>Email:</strong>{" "}
+            <a href="mailto:support@foodflow.ca" style={styles.link}>
+              support@foodflow.ca
+            </a>
+            <br />
+            <strong>Address:</strong> Montréal, QC, Canada
+          </p>
+        </section>
+
+        <div style={styles.footer}>
+          <button
+            style={hover ? { ...styles.button, ...styles.buttonHover } : styles.button}
+            onMouseEnter={() => setHover(true)}
+            onMouseLeave={() => setHover(false)}
+            onClick={() => (window.location.href = "/")}
+          >
+            Back to Home
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PrivacyPolicy;

--- a/frontend/src/components/RegisterType.css
+++ b/frontend/src/components/RegisterType.css
@@ -331,3 +331,27 @@
         font-size: 0.9rem;
     }
 }
+
+.back-home-button {
+  position: absolute;
+  top: 24px;
+  right: 32px;
+  background: transparent;
+  color: #1B4965;
+  border: none;
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+  text-decoration: underline;
+  transition: color 0.2s ease;
+}
+
+.back-home-button:hover {
+  color: #609B7E;
+}
+
+.back-home-button:focus-visible {
+  outline: 2px solid #609B7E;
+  outline-offset: 2px;
+  border-radius: 4px;
+}

--- a/frontend/src/components/RegisterType.js
+++ b/frontend/src/components/RegisterType.js
@@ -10,6 +10,13 @@ const RegisterType = () => {
 
   return (
     <div className="register-type-page">
+      <button
+        className="back-home-button"
+        onClick={() => navigate("/")}
+        aria-label="Go back to homepage"
+      >
+        ← Back Home
+      </button>
       <div className="intro">
         <h1>Join FoodFlow</h1>
         <p>

--- a/frontend/src/style/LoginPage.css
+++ b/frontend/src/style/LoginPage.css
@@ -115,3 +115,27 @@
           .login-right{padding:0}
           .login-card{padding:0}
         }
+
+.back-home-button {
+  position: absolute;
+  top: 24px;
+  right: 32px;
+  background: transparent;
+  color: var(--brand);
+  border: none;
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+  text-decoration: underline;
+  transition: color 0.2s ease;
+}
+
+.back-home-button:hover {
+  color: var(--accent);
+}
+
+.back-home-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}

--- a/frontend/src/style/LoginPage.css
+++ b/frontend/src/style/LoginPage.css
@@ -65,6 +65,29 @@
         .form-footer a{color:var(--brand);text-decoration:underline}
         .footer-copy{position:absolute;left:18px;bottom:14px;color:rgba(255,255,255,.85);font-size:12px}
 
+        .link-button{
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: var(--brand);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.form-footer .link-button{
+  color: var(--brand);
+  text-decoration: underline;
+}
+
+.form-footer .link-button:focus-visible{
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+  text-decoration: none;
+}
+
         /* Responsive */
         @media (max-width: 1024px){
           .login-inner{padding:36px 24px}

--- a/frontend/src/test/LoginPage.test.js
+++ b/frontend/src/test/LoginPage.test.js
@@ -80,8 +80,11 @@ describe('LoginPage', () => {
     const forgot = screen.getByRole('link', { name: /forgot password\?/i });
     expect(forgot).toHaveAttribute('href', '/forgot-password');
 
-    const signup = screen.getByRole('link', { name: /sign up/i });
-    expect(signup).toHaveAttribute('href', '/signup');
+
+    const signupBtn = screen.getByRole('button', { name: /sign up/i });
+    expect(signupBtn).toBeInTheDocument();
+    fireEvent.click(signupBtn);
+    expect(mockNavigate).toHaveBeenCalledWith('/register');
   });
 
   test('password visibility toggle switches input type and aria-label', () => {


### PR DESCRIPTION
# Add "Back Home" Navigation and Adjust Login Page Tests

This is linked to #55 

## Description
Improved the authentication flow for better UX consistency and navigation clarity:
- Added **“← Back Home”** button to both Login and Register pages.
- Removed Navbar from Login and Register routes for a cleaner layout.
- Updated Footer: made email and phone clickable (mailto/tel links).
- Changed **“Sign up”** from a link to a button using programmatic navigation.
- Adjusted corresponding test (`LoginPage.test.js`) to reflect these changes.

### Subpoint 1
- Added Back Home buttons and matching styles.

### Subpoint 2
- Removed Navbar display on auth routes using `useLocation()`.

### Subpoint 3
- Updated Footer contact info and adjusted login tests.

## Testing

### Setup
- Run `npm start` → verify Back Home button and no Navbar on auth pages.
- Run `npm test src/test/LoginPage.test.js` → all tests pass.
- Check Footer links open email client and phone dialer.