### PR TITLE
Weekly coverage reports pipeline

### DIFF
--- a/.github/workflows/weekly-coverage.yml
+++ b/.github/workflows/weekly-coverage.yml
@@ -1,10 +1,6 @@
 name: Weekly Coverage Reports
 
 on:
-  push:
-    branches:
-      - 'main'
-      - 'coverage-reports-pipeline'
   schedule:
     # Runs every Monday at 7 AM UTC
     - cron: '0 7 * * 1'


### PR DESCRIPTION
This linked to #154 

## Description
This PR implements a new pipeline that will automatically generate weekly coverage reports for both frontend and backend. It will then upload the generated reports as GitHub Actions artifacts and also post a summary of the coverages for both frontend and backend.

### Pipeline Overview
#### Frontend
- Runs Jest tests with coverage (`npm run test:coverage`).
- Gets the coverage report from `coverage/lcov-report/index.html` and also parses the file to get coverage summary.

#### Backend
- Starts up the PostgreSQL database.
- Runs the test coverage with this command: `./mvnw jacoco:report`.
- Gets the coverage report from `target/site/jacoco/index.html`.
- Parses the index.html file to extract coverage summary.
- Uploads the file as an artifact in GitHub Actions.

## Testing

- Pushed a commit to trigger the pipeline (only for testing purposes) 
- Confirm that both the frontend and backend jobs were successfully completed and that both artifacts were uploaded.
- Confirm that 'Weekly Coverage Report' is visible in the workflow summary.
