### PR TITLE
Fix: Retain Textbox Focus After Sending Message

### DIFF
--- a/frontend/src/components/MessagingDashboard/ChatPanel.js
+++ b/frontend/src/components/MessagingDashboard/ChatPanel.js
@@ -143,12 +143,12 @@ const ChatPanel = ({
       setNewMessage('');
       ga4Service.trackMessageSent();
       onMessageSent();
-      textareaRef.current?.focus();
     } catch (err) {
       console.error('Error sending message:', err);
       alert(t('chat.failedToSend'));
     } finally {
       setSending(false);
+      textareaRef.current?.focus();
     }
   };
 


### PR DESCRIPTION
This is linked to #401 
Description
After sending a message in the Messages tab, the input field lost focus requiring the user to click back into the textbox to continue typing. This fix ensures the cursor automatically remains in the textbox after sending.
Change:

Added textareaRef.current?.focus() in handleSendMessage after message is sent in ChatPanel.js

Trigger Coverage:

Focus is retained when sending via the Send button
Focus is retained when sending via the Enter key
Both triggers funnel through the same handleSendMessage function

Notes:

textareaRef was already declared and attached to the textarea
No new refs or state introduced
No existing functionality modified